### PR TITLE
fix(script): Incorrect use of script calls

### DIFF
--- a/Bunker Research Unlocker.lua
+++ b/Bunker Research Unlocker.lua
@@ -4,79 +4,75 @@ local individual_unlocks_tab = bunker_research:add_tab("Unlock One By One")
 
 local function add_unlock_button(tab, name, stat_id)
     tab:add_button(name, function()
-        script.run_in_fiber(function()
-            script.execute_as_script("shop_controller", function()
-                stats.set_packed_stat_bool(stat_id, true)
-                gui.show_message("Bunker Research Unlocker", name .. " has been unlocked!")
-            end)
-        end)
+	    script.execute_as_script("shop_controller", function()
+			stats.set_packed_stat_bool(stat_id, true)
+			gui.show_message("Bunker Research Unlocker", name .. " has been unlocked!")
+	    end)
     end)
 end
 
 local function unlock_all_research()
-    script.run_in_fiber(function()
-        script.execute_as_script("shop_controller", function()
-            local unlocks = {
-                { "APC SAM Battery", 15381 },
-                { "Ballistic Equipment", 15382 },
-                { "Half-track 20mm Quad Autocannon", 15428 },
-                { "Weaponized Tampa Dual Remote Minigun", 15429 },
-                { "Weaponized Tampa Rear-Firing Mortar", 15430 },
-                { "Weaponized Tampa Front Missile Launchers", 15431 },
-                { "Dune FAV 40mm Grenade Launcher", 15432 },
-                { "Dune FAV 7.62mm Minigun", 15433 },
-                { "Insurgent Pick-Up Custom .50 Cal Minigun", 15434 },
-                { "Insurgent Pick-Up Custom Heavy Armor Plating", 15435 },
-                { "Technical Custom 7.62mm Minigun", 15436 },
-                { "Technical Custom Ram-bar", 15437 },
-                { "Technical Custom Brute-bar", 15438 },
-                { "Technical Custom Heavy Chassis Armor", 15439 },
-                { "Oppressor Missiles", 15447 },
-                { "Fractal Livery Set", 15448 },
-                { "Digital Livery Set", 15449 },
-                { "Geometric Livery Set", 15450 },
-                { "Nature Reserve Livery", 15451 },
-                { "Naval Battle Livery", 15452 },
-                { "Anti-Aircraft Trailer Dual 20mm Flak", 15453 },
-                { "Anti-Aircraft Trailer Homing Missile Battery", 15454 },
-                { "Mobile Operations Center Rear Turrets", 15455 },
-                { "Incendiary Rounds", 15456 },
-                { "Hollow Point Rounds", 15457 },
-                { "Armor Piercing Rounds", 15458 },
-                { "Full Metal Jacket Rounds", 15459 },
-                { "Explosive Rounds", 15460 },
-                { "Pistol Mk II Mounted Scope", 15461 },
-                { "Pistol Mk II Compensator", 15462 },
-                { "SMG Mk II Holographic Sight", 15463 },
-                { "SMG Mk II Heavy Barrel", 15464 },
-                { "Heavy Sniper Mk II Night Vision Scope", 15465 },
-                { "Heavy Sniper Mk II Thermal Scope", 15466 },
-                { "Heavy Sniper Mk II Heavy Barrel", 15467 },
-                { "Combat MG Mk II Holographic Sight", 15468 },
-                { "Combat MG Mk II Heavy Barrel", 15469 },
-                { "Assault Rifle Mk II Holographic Sight", 15470 },
-                { "Assault Rifle Mk II Heavy Barrel", 15471 },
-                { "Carbine Rifle Mk II Holographic Sight", 15472 },
-                { "Carbine Rifle Mk II Heavy Barrel", 15473 },
-                { "Proximity Mines", 15474 },
-				{ "Weaponized Tampa Heavy Chassis Armor", 15491 },
-				{ "Brushstroke Camo Mk II Weapon Livery", 15492 },
-				{ "Skull Mk II Weapon Livery", 15493 },
-				{ "Sessanta Nove Mk II Weapon Livery", 15494 },
-				{ "Perseus Mk II Weapon Livery", 15495 },
-				{ "Leopard Mk II Weapon Livery", 15496 },
-				{ "Zebra Mk II Weapon Livery", 15497 },
-				{ "Geometric Mk II Weapon Livery", 15498 },
-                { "Boom! Mk II Weapon Livery", 15499 }
-            }
+	script.execute_as_script("shop_controller", function()
+		local unlocks = {
+			{ "APC SAM Battery", 15381 },
+			{ "Ballistic Equipment", 15382 },
+			{ "Half-track 20mm Quad Autocannon", 15428 },
+			{ "Weaponized Tampa Dual Remote Minigun", 15429 },
+			{ "Weaponized Tampa Rear-Firing Mortar", 15430 },
+			{ "Weaponized Tampa Front Missile Launchers", 15431 },
+			{ "Dune FAV 40mm Grenade Launcher", 15432 },
+			{ "Dune FAV 7.62mm Minigun", 15433 },
+			{ "Insurgent Pick-Up Custom .50 Cal Minigun", 15434 },
+			{ "Insurgent Pick-Up Custom Heavy Armor Plating", 15435 },
+			{ "Technical Custom 7.62mm Minigun", 15436 },
+			{ "Technical Custom Ram-bar", 15437 },
+			{ "Technical Custom Brute-bar", 15438 },
+			{ "Technical Custom Heavy Chassis Armor", 15439 },
+			{ "Oppressor Missiles", 15447 },
+			{ "Fractal Livery Set", 15448 },
+			{ "Digital Livery Set", 15449 },
+			{ "Geometric Livery Set", 15450 },
+			{ "Nature Reserve Livery", 15451 },
+			{ "Naval Battle Livery", 15452 },
+			{ "Anti-Aircraft Trailer Dual 20mm Flak", 15453 },
+			{ "Anti-Aircraft Trailer Homing Missile Battery", 15454 },
+			{ "Mobile Operations Center Rear Turrets", 15455 },
+			{ "Incendiary Rounds", 15456 },
+			{ "Hollow Point Rounds", 15457 },
+			{ "Armor Piercing Rounds", 15458 },
+			{ "Full Metal Jacket Rounds", 15459 },
+			{ "Explosive Rounds", 15460 },
+			{ "Pistol Mk II Mounted Scope", 15461 },
+			{ "Pistol Mk II Compensator", 15462 },
+			{ "SMG Mk II Holographic Sight", 15463 },
+			{ "SMG Mk II Heavy Barrel", 15464 },
+			{ "Heavy Sniper Mk II Night Vision Scope", 15465 },
+			{ "Heavy Sniper Mk II Thermal Scope", 15466 },
+			{ "Heavy Sniper Mk II Heavy Barrel", 15467 },
+			{ "Combat MG Mk II Holographic Sight", 15468 },
+			{ "Combat MG Mk II Heavy Barrel", 15469 },
+			{ "Assault Rifle Mk II Holographic Sight", 15470 },
+			{ "Assault Rifle Mk II Heavy Barrel", 15471 },
+			{ "Carbine Rifle Mk II Holographic Sight", 15472 },
+			{ "Carbine Rifle Mk II Heavy Barrel", 15473 },
+			{ "Proximity Mines", 15474 },
+			{ "Weaponized Tampa Heavy Chassis Armor", 15491 },
+			{ "Brushstroke Camo Mk II Weapon Livery", 15492 },
+			{ "Skull Mk II Weapon Livery", 15493 },
+			{ "Sessanta Nove Mk II Weapon Livery", 15494 },
+			{ "Perseus Mk II Weapon Livery", 15495 },
+			{ "Leopard Mk II Weapon Livery", 15496 },
+			{ "Zebra Mk II Weapon Livery", 15497 },
+			{ "Geometric Mk II Weapon Livery", 15498 },
+			{ "Boom! Mk II Weapon Livery", 15499 }
+		}
 
-            for _, unlock in ipairs(unlocks) do
-                stats.set_packed_stat_bool(unlock[2], true)
-            end
+		for _, unlock in ipairs(unlocks) do
+			stats.set_packed_stat_bool(unlock[2], true)
+		end
 
-            gui.show_message("Bunker Research Unlocker", "All research items have been unlocked!")
-        end)
-    end)
+		gui.show_message("Bunker Research Unlocker", "All research items have been unlocked!")
+	end)
 end
 
 bunker_research:add_button("Unlock All Bunker Research", unlock_all_research)


### PR DESCRIPTION
- `run_in_fiber()` executes your code in the `main_persistent` thread.
- `execute_as_script()` runs it in the provided thread.
- `run_in_fiber(func)` is the same as `script.execute_as_script("main_persistent", func)`

Use one of the two, not both at the same time.